### PR TITLE
Add async functionality to model object field

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,104 @@
+# Flexible Content for OctoberCMS
+
+Inspired by the the Advanced Custom Fields PRO plugin for Wordpress, this plugin allows you to
+create flexible content blocks for your OctoberCMS website. This plugin will take care of the
+editing part, and the rendering part.
+
+This package also contains a [flexible model object field](#flexible-model-object-field) 'fc-model-object' for searchable
+select (Select2) that allows you to select a model object and use it in your flexible
+content block, without having an eloquent relation to the model.
+
+## Installation
+
+```bash
+composer require grrramsterdam/flexiblecontent-plugin
+```
+
+## Usage
+
+You can add flexible content blocks by adding them to themes/your-theme/flexible-content/groups.yaml.
+This is essentially the `groups` option a [repeater](https://docs.octobercms.com/1.x/backend/forms.html#repeater) field. Each group must specify a unique key and the definition supports the
+following options. name, description, icon en fields.
+
+Example:
+
+```yaml
+text:
+  name: Text
+  description: A simple text block
+  icon: icon-align-left
+  fields:
+    text:
+      label: Text
+      type: richeditor
+text_media:
+  name: Text with media
+  description: A text block with media
+  icon: icon-align-left
+  fields:
+    text:
+      label: Text
+      type: richeditor
+    media:
+      label: Media
+      type: mediafinder
+```
+
+## Flexible model object field
+
+With this field you can create a searchable model object field that can be used in your flexible content block. You can use this field to select a model object without having an eloquent relation to the model.
+
+### Usage
+
+```yaml
+fields:
+  model_object:
+    label: Pick example
+    type: fc-model-object
+    model: Grrr\FlexibleContent\Models\ExampleModel
+    nameFrom: title
+    emptyOption: "Select an example item"
+    # searchEndpoint: grrr/project-plugin/example-models/search-select-options
+```
+
+### Asynchronous select options
+
+By default an `all()` query will be done for the model to dynamically populate the select options.
+But this can be a memory issue very quickly. You can specify a `searchEndpoint` option. This should
+be a route to an OctoberCMS backend controller that returns a JSON response with the following
+format:
+
+```json
+{
+  "results": [
+    {
+      "id": 1,
+      "text": "Example item 1"
+    },
+    {
+      "id": 2,
+      "text": "Example item 2"
+    }
+  ]
+}
+```
+
+This packages provides a behaviour `GrrrAmsterdam\FlexibleContent\Behaviors\HasSearchableSelectOptions`
+that you can use in a controller that also uses the FormController behaviour. Register it in a
+controller like this:
+
+```php
+// [plugin path]/controllers/Examples.php
+
+public $implement = [
+    'Backend\Behaviors\FormController',
+    'GrrrAmsterdam\FlexibleContent\Behaviors\HasSearchableSelectOptions',
+];
+```
+
+Be the default the search query will be done on the `title` attribute of the model. You can overwrite
+the `getSearchableSelectOptions()` method on your controller to change this behaviour.
+
+This behaviour will add a route to the controller with the following backend path:
+`{vendor}/{plugin}/{controller}/search-select-options`. You can use this path as the `searchEndpoint`
+option.

--- a/behaviors/HasSearchableSelectOptions.php
+++ b/behaviors/HasSearchableSelectOptions.php
@@ -1,0 +1,50 @@
+<?php namespace GrrrAmsterdam\FlexibleContent\Behaviors;
+
+use Backend\Classes\Controller;
+use Illuminate\Database\Eloquent\Builder;
+use October\Rain\Database\Model;
+use October\Rain\Extension\ExtensionBase;
+
+class HasSearchableSelectOptions extends ExtensionBase {
+
+    protected $parent;
+
+    public function __construct(Controller $parent) {
+        $this->parent = $parent;
+    }
+
+    public function searchSelectOptions() {
+        $searchQuery = request()->get('term');
+        $optionLabelFrom = request()->get('name_from', 'title');
+
+        $model = $this->parent->formCreateModelObject();
+
+        $dbQuery = $model->newQuery();
+
+        $items = $dbQuery->when($searchQuery, function (Builder $query) use ($searchQuery) {
+            return $this->parent->selectOptionsQuery($query, $searchQuery);
+        })->limit(10)->get();
+
+        // Results are expected to be in the format { id: 1, text: 'foo' }
+        $results = $items->map(function (Model $item) use ($optionLabelFrom) {
+            $primaryKey = $item->getKeyName();
+            return [
+                'id' => $item->$primaryKey,
+                'text' => $item->$optionLabelFrom,
+            ];
+        });
+        $data = [
+            'results' => $results->toArray(),
+            "pagination" => [
+                // TODO: implement pagination
+                "more" => false,
+            ],
+        ];
+        return response()->json($data);
+    }
+
+    public function selectOptionsQuery(Builder $query, string $searchQuery): Builder {
+        return $query->where('title', 'like', '%' . $searchQuery . '%');
+    }
+
+}

--- a/formwidgets/ModelObject.php
+++ b/formwidgets/ModelObject.php
@@ -1,7 +1,10 @@
 <?php namespace GrrrAmsterdam\FlexibleContent\FormWidgets;
 
 use Backend\Classes\FormWidgetBase;
+use Backend\Facades\Backend;
 use Garp\Functional as f;
+use Illuminate\Database\Eloquent\Collection;
+use October\Rain\Database\Model;
 
 class ModelObject extends FormWidgetBase {
 
@@ -13,34 +16,41 @@ class ModelObject extends FormWidgetBase {
 
     public $emptyOption;
 
+    public ?string $searchEndpoint = null;
+
+    public string $optionLabelFrom = 'title';
+
     public function init() {
         $this->fillFromConfig([
             'modelClass',
             'nameFrom',
             'emptyOption',
+            'searchEndpoint',
         ]);
         parent::init();
+    }
+
+    public function loadAssets()
+    {
+        $assetsPath = '/plugins/grrramsterdam/flexiblecontent/formwidgets/modelobject/assets';
+        $this->addJs($assetsPath ."/js/modelobject.js", [
+            "build" => "Grrr.FlexibleContent",
+            "defer" => true,
+        ]);
     }
 
     public function render() {
         $this->vars['id'] = $this->getId();
         $this->vars['name'] = $this->getFieldName();
         $this->vars['value'] = $this->getLoadValue();
-        $this->vars['options'] = $this->getFieldOptions();
-        $this->vars['emptyOption'] = $this->emptyOption;
 
+        $this->vars['options'] = $this->getFieldOptions($this->vars['value']);
+        $this->vars['emptyOption'] = $this->emptyOption;
+        $this->vars['searchEndpoint'] = $this->getSearchEndpoint();
+        $this->vars['nameFrom'] = $this->nameFrom;
         return $this->makePartial('fc-object-field');
     }
 
-    protected function getFieldOptions() {
-        $model = new $this->modelClass;
-        $items = $model->all();
-        $nameFrom = $this->nameFrom;
-        $options = $items->mapWithKeys(function ($item) use ($nameFrom) {
-            return [$item->id => $item->$nameFrom];
-        });
-        return $options->toArray();
-    }
 
     public function getLoadValue() {
         $value = parent::getLoadValue();
@@ -54,4 +64,38 @@ class ModelObject extends FormWidgetBase {
         ];
     }
 
+    /**
+     * Get field options for select
+     *
+     * @param string $currentValue  The current value of the field (the id of the model)
+     *                              to be able to set the selected option
+     * @return array
+     */
+    protected function getFieldOptions(?string $currentValue): array {
+        $model = new $this->modelClass;
+        $items = $this->searchEndpoint
+            ? $this->getLatestItemsIncludingCurrent($model, $currentValue)
+            : $model->all();
+
+        $nameFrom = $this->nameFrom;
+        $options = $items->mapWithKeys(function ($item) use ($nameFrom) {
+            $primaryKey = $item->getKeyName();
+            return [$item->$primaryKey => $item->$nameFrom];
+        });
+        return $options->toArray();
+    }
+
+    protected function getSearchEndpoint() {
+        if (!$this->searchEndpoint) {
+            return null;
+        }
+        return Backend::url($this->searchEndpoint);
+    }
+
+    protected function getLatestItemsIncludingCurrent(Model $model, ?string $currentValue): Collection {
+        $primaryKey = $model->getKeyName();
+
+        $items = $model->where($primaryKey, $currentValue)->get();
+        return $items->merge($model->limit(10)->get());
+    }
 }

--- a/formwidgets/modelobject/assets/js/modelobject.js
+++ b/formwidgets/modelobject/assets/js/modelobject.js
@@ -1,0 +1,23 @@
+const SELECT_SELECTOR = '.model-object-field';
+const SEARCH_ENDPOINT_ATTRIBUTE = 'data-search-endpoint';
+const NAME_FROM_ATTRIBUTE = 'data-name-from';
+
+$(document).render(function () {
+  $(SELECT_SELECTOR).each(function (index, select) {
+    const searchEndpoint = select.getAttribute(SEARCH_ENDPOINT_ATTRIBUTE);
+    const optionLabelFrom = select.getAttribute(NAME_FROM_ATTRIBUTE);
+
+    const select2Options = searchEndpoint ? {
+      ajax: {
+        url: searchEndpoint,
+        dataType: 'json',
+        data: function (params) {
+          params['name_from'] = optionLabelFrom;
+          return params;
+        },
+      }
+    } : {};
+
+    $(select).select2(select2Options);
+  });
+});

--- a/formwidgets/modelobject/partials/_fc-object-field.htm
+++ b/formwidgets/modelobject/partials/_fc-object-field.htm
@@ -1,5 +1,7 @@
 <select name="<?= $name ?>" id="<?= $id ?>"
-    class="form-control custom-select">
+    data-search-endpoint="<?= $searchEndpoint ?>"
+    data-name-from="<?= $nameFrom ?>"
+    class="form-control model-object-field">
     <?php if ($emptyOption): ?>
         <option value=""><?= $emptyOption ?></option>
     <?php endif ?>


### PR DESCRIPTION
Before this feature, select options where populated with an `all()` query. This is not scalable.

Now you can use the select2 ajax functionality to fetch the options remote.